### PR TITLE
use Path.Combine for cross-platform support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,14 @@ A pre-compiled binary is available for [download from my website](https://viller
  - [SharpZipLip](http://icsharpcode.github.io/SharpZipLib/), a .NET zipping library. Used to decompress archive files
  - [SoX](http://sox.sourceforge.net/) (not included in repository), a command line utility for editing sound files. Used to merge soundchunks.
 
+####Compiling under Linux
+
+In Debian and derivatives (Ubuntu, Mint) download the build dependencies and build like this:
+
+	$ apt-get install mono-mcs mono-xbuild
+	$ xbuild /p:Configuration=Release RSCacheTool.csproj
+
+
 ####Be a nice guy and help me out
 
 If you like this tool you can show your appreciation by helping me complete my music archive. If you have any named extraced music files that do not exist in [my archive](https://villermen.com/browser/?d=music/Runescape%203), please share them with me in whatever way possible (dropbox, drive, puush, you name it). A small PayPal donation (villermen@gmail.com) wouldn't hurt either!


### PR DESCRIPTION
Hi,

using mono, RSCacheTool runs on Linux after applying this patch. Please consider applying it.

Thanks!